### PR TITLE
グループコントローラーにアクションを定義

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,10 @@
 class GroupsController < ApplicationController
+  def new
+  end
+  def create
+  end
+  def edit
+  end
+  def update
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'messages#index'
-  resources :users, only: [:edit, :update, :destroy]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] 
 end


### PR DESCRIPTION
# Why
グループコントローラーに該当アクションを定義した。

# Why
グループの登録、編集機能に必要となるアクションのため。