### PR TITLE
最新メッセージの表示、グループ情報の表示

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,4 +2,11 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
   has_many :messages
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -5,7 +5,9 @@
         .group__header__detail__info__name
           = @group.name
         .group__header__detail__info__member
-          Member:
+          - @group.users.each do |user|
+            Member:
+            = user.name
       .group__header__edit
         Edit
   .group__chats

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -17,4 +17,4 @@
             .wrapper__side_bar__groups__view__name
               = group.name
             .wrapper__side_bar__groups__view__message
-              メッセージはまだありません。
+              = group.show_last_message


### PR DESCRIPTION
# What
最新メッセージの表示、グループ情報の表示

# Why
サイドバーからグループのチャット内容の一部を閲覧可能にするため。